### PR TITLE
Removed application launcher icons as it is not an app.

### DIFF
--- a/KitKatEmoji/src/main/AndroidManifest.xml
+++ b/KitKatEmoji/src/main/AndroidManifest.xml
@@ -1,11 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.klpu.emoji">
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher"
->
-
-    </application>
-
+    <application/>
 </manifest>


### PR DESCRIPTION
This is a library and as such it doesn't need to have launcher and name declared. As a matter of fact it's currently failing one of my builds even though I'm using `tools:replace="android:icon"` in my application xml tag.
